### PR TITLE
fix audio recorder input device change handling

### DIFF
--- a/Sources/Speakboard/AudioRecorder.swift
+++ b/Sources/Speakboard/AudioRecorder.swift
@@ -1,22 +1,55 @@
 import AVFoundation
+import CoreAudio
 
 // Streams real-time PCM i16 LE audio at 16 kHz mono to the provided onChunk callback.
 // Each call to onChunk delivers a Data blob containing raw 16-bit signed little-endian samples.
 final class AudioRecorder {
+
+    private struct InputFormatKey: Equatable {
+        let sampleRate: Double
+        let channelCount: AVAudioChannelCount
+        let commonFormatRawValue: Int
+        let isInterleaved: Bool
+
+        init(_ format: AVAudioFormat) {
+            sampleRate = format.sampleRate
+            channelCount = format.channelCount
+            commonFormatRawValue = Int(format.commonFormat.rawValue)
+            isInterleaved = format.isInterleaved
+        }
+    }
+
+    private struct HardwareListener {
+        var address: AudioObjectPropertyAddress
+        let block: AudioObjectPropertyListenerBlock
+    }
 
     private(set) var isRecording = false
 
     /// Called on the AVAudioEngine internal thread with raw i16 LE PCM at 16 kHz mono.
     var onChunk: ((Data) -> Void)?
 
-    private let engine = AVAudioEngine()
+    private var engine: AVAudioEngine?
     private var converter: AVAudioConverter?
+    private var converterInputFormat: InputFormatKey?
     private let outputFormat = AVAudioFormat(
         commonFormat: .pcmFormatFloat32,
         sampleRate: 16_000,
         channels: 1,
         interleaved: false
     )!
+    private var audioChainDirty = true
+    private var engineConfigObserver: NSObjectProtocol?
+    private var hardwareListeners: [HardwareListener] = []
+
+    init() {
+        registerHardwareListeners()
+    }
+
+    deinit {
+        unregisterHardwareListeners()
+        removeEngineObserver()
+    }
 
     // MARK: - Public
 
@@ -45,28 +78,35 @@ final class AudioRecorder {
     func stopRecording() {
         guard isRecording else { return }
         isRecording = false
-        engine.inputNode.removeTap(onBus: 0)
-        engine.stop()
+        engine?.inputNode.removeTap(onBus: 0)
+        engine?.stop()
         converter = nil
+        converterInputFormat = nil
+
+        if audioChainDirty {
+            teardownEngine()
+        }
     }
 
     // MARK: - Private
 
     private func doStart() throws {
-        let inputNode = engine.inputNode
-        let inputFormat = inputNode.outputFormat(forBus: 0)
+        rebuildEngineIfNeeded()
 
-        guard let conv = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+        guard let engine else {
             throw NSError(domain: "AudioRecorder", code: 2,
-                          userInfo: [NSLocalizedDescriptionKey: "Cannot create audio converter."])
+                          userInfo: [NSLocalizedDescriptionKey: "Cannot create audio engine."])
         }
-        converter = conv
 
-        let ratio = outputFormat.sampleRate / inputFormat.sampleRate
+        let inputNode = engine.inputNode
+        inputNode.removeTap(onBus: 0)
 
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] inBuf, _ in
-            guard let self, let conv = self.converter else { return }
+        // Let AVAudioEngine pick the bus format so a device switch does not leave us
+        // installing a tap with a stale format from the previous input route.
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: nil) { [weak self] inBuf, _ in
+            guard let self, let conv = self.converter(for: inBuf.format) else { return }
 
+            let ratio = self.outputFormat.sampleRate / inBuf.format.sampleRate
             let outCapacity = AVAudioFrameCount(Double(inBuf.frameLength) * ratio + 1)
             guard let outBuf = AVAudioPCMBuffer(pcmFormat: self.outputFormat,
                                                 frameCapacity: outCapacity) else { return }
@@ -91,6 +131,110 @@ final class AudioRecorder {
 
         try engine.start()
         isRecording = true
+    }
+
+    private func converter(for inputFormat: AVAudioFormat) -> AVAudioConverter? {
+        let key = InputFormatKey(inputFormat)
+        if converterInputFormat == key, let converter {
+            return converter
+        }
+
+        guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+            print("[recorder] cannot create audio converter for input format: \(inputFormat)")
+            return nil
+        }
+
+        self.converter = converter
+        converterInputFormat = key
+        return converter
+    }
+
+    private func rebuildEngineIfNeeded() {
+        guard engine == nil || audioChainDirty else { return }
+        teardownEngine()
+
+        let engine = AVAudioEngine()
+        self.engine = engine
+        audioChainDirty = false
+
+        engineConfigObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: engine,
+            queue: .main
+        ) { [weak self] _ in
+            self?.markAudioChainDirty()
+        }
+    }
+
+    private func teardownEngine() {
+        engine?.inputNode.removeTap(onBus: 0)
+        engine?.stop()
+        removeEngineObserver()
+        engine = nil
+        converter = nil
+        converterInputFormat = nil
+    }
+
+    private func markAudioChainDirty() {
+        audioChainDirty = true
+        converter = nil
+        converterInputFormat = nil
+
+        if !isRecording {
+            teardownEngine()
+        }
+    }
+
+    private func registerHardwareListeners() {
+        let selectors: [AudioObjectPropertySelector] = [
+            kAudioHardwarePropertyDefaultInputDevice,
+            kAudioHardwarePropertyDevices,
+        ]
+
+        for selector in selectors {
+            var address = AudioObjectPropertyAddress(
+                mSelector: selector,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+
+            let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+                self?.markAudioChainDirty()
+            }
+
+            let status = AudioObjectAddPropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject),
+                &address,
+                DispatchQueue.main,
+                block
+            )
+
+            if status == noErr {
+                hardwareListeners.append(HardwareListener(address: address, block: block))
+            } else {
+                print("[recorder] failed to add hardware listener: \(status)")
+            }
+        }
+    }
+
+    private func unregisterHardwareListeners() {
+        for listener in hardwareListeners {
+            var address = listener.address
+            AudioObjectRemovePropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject),
+                &address,
+                DispatchQueue.main,
+                listener.block
+            )
+        }
+        hardwareListeners.removeAll()
+    }
+
+    private func removeEngineObserver() {
+        if let observer = engineConfigObserver {
+            NotificationCenter.default.removeObserver(observer)
+            engineConfigObserver = nil
+        }
     }
 
     // MARK: - Float32 mono → i16 LE


### PR DESCRIPTION
## Summary
- listen for macOS input device and hardware changes so stale audio recorder state is invalidated when the input route changes
- rebuild the recorder engine only when needed and let `AVAudioEngine` choose the active tap format instead of reusing a stale one
- recreate the audio converter from the actual input buffer format to keep 16 kHz mono conversion aligned with the active microphone

## Test plan
- [x] `swift build`
- [x] manually switch the system input device between sessions and confirm recording no longer crashes with a tap format mismatch
- [x] manually switch the input device during an active recording and confirm the app stays stable even if audio after the switch is dropped

Closes #5.

Made with [Cursor](https://cursor.com)