### PR TITLE
Adopt local IPC sidecar transport in the macOS app

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
             linkerSettings: [
                 // Carbon is needed for RegisterEventHotKey (global hotkey, no Accessibility permission required).
                 .linkedFramework("Carbon"),
+                .linkedFramework("Network"),
             ]
         ),
     ]

--- a/Sources/Speakboard/FloatingPanelController.swift
+++ b/Sources/Speakboard/FloatingPanelController.swift
@@ -46,7 +46,7 @@ final class FloatingPanelController: NSObject {
 
     override init() {
         super.init()
-        // Wire recorder's real-time chunks directly to the WebSocket.
+        // Wire recorder's real-time chunks directly to the sidecar transport.
         // The closure is set once; it reads sidecar lazily at call time.
         recorder.onChunk = { [weak self] data in
             self?.sidecar?.sendAudioChunk(data)
@@ -104,7 +104,7 @@ final class FloatingPanelController: NSObject {
         state = .recording(.shortPress)
         contentView?.enterRecordingState(.shortPress)
 
-        // Begin a new WebSocket session before sending audio chunks.
+        // Begin a new sidecar session before sending audio chunks.
         sidecar?.beginSession()
 
         recorder.startRecording { error in
@@ -173,7 +173,7 @@ final class FloatingPanelController: NSObject {
         recorder.stopRecording()
         switch state {
         case .recording:
-            // Cancel the WebSocket session without triggering transcription.
+            // Cancel the current sidecar session without triggering transcription.
             sidecar?.cancelSession()
         case .transcribing:
             // Suppress the result that is already in flight.

--- a/Sources/Speakboard/SettingsStore.swift
+++ b/Sources/Speakboard/SettingsStore.swift
@@ -18,7 +18,12 @@ final class SettingsStore {
 
     // MARK: - Defaults (must match backend's ResolvedConfig::default())
 
+    static let defaultTransportKind: BackendTransportKind = .unixDomainSocket
     static let defaultPort: Int = 8080
+    static let defaultSocketPath: String = FileManager.default
+        .temporaryDirectory
+        .appendingPathComponent("speakboard-sidecar.sock")
+        .path
     static let defaultNumThreads: Int = 4
     static let defaultSilenceRmsThreshold: Double = 0.02
     static let defaultPartialSilenceSecs: Double = 0.8
@@ -32,9 +37,23 @@ final class SettingsStore {
     private let ud = UserDefaults.standard
     private let ns = "speakboard.backend."
 
+    var transportKind: BackendTransportKind {
+        get {
+            guard let raw = ud.string(forKey: ns + "transport"),
+                  let kind = BackendTransportKind(rawValue: raw) else {
+                return Self.defaultTransportKind
+            }
+            return kind
+        }
+        set { ud.set(newValue.rawValue, forKey: ns + "transport") }
+    }
     var port: Int {
         get { ud.object(forKey: ns + "port") as? Int ?? Self.defaultPort }
         set { ud.set(newValue, forKey: ns + "port") }
+    }
+    var socketPath: String {
+        get { ud.string(forKey: ns + "socketPath") ?? Self.defaultSocketPath }
+        set { ud.set(newValue, forKey: ns + "socketPath") }
     }
     var numThreads: Int {
         get { ud.object(forKey: ns + "numThreads") as? Int ?? Self.defaultNumThreads }
@@ -89,10 +108,22 @@ final class SettingsStore {
         set { ud.set(newValue, forKey: ns + "hotkeyModifiers") }
     }
 
+    var sidecarEndpoint: SidecarEndpoint {
+        switch transportKind {
+        case .unixDomainSocket:
+            let path = socketPath.trimmingCharacters(in: .whitespacesAndNewlines)
+            return .unix(path: path.isEmpty ? Self.defaultSocketPath : path)
+        case .loopbackTcp:
+            let clampedPort = UInt16(max(1, min(port, Int(UInt16.max))))
+            return .loopbackTcp(host: "127.0.0.1", port: clampedPort)
+        }
+    }
+
     // MARK: - Reset
 
     func resetToDefaults() {
-        [ns + "port", ns + "numThreads", ns + "silenceRmsThreshold",
+        [ns + "transport", ns + "port", ns + "socketPath",
+         ns + "numThreads", ns + "silenceRmsThreshold",
          ns + "partialSilenceSecs", ns + "goldSilenceSecs", ns + "maxGoldSecs",
          ns + "minTranscribeSecs", ns + "minSpeechSecs",
          ns + "modelPath", ns + "tokensPath",
@@ -114,7 +145,7 @@ final class SettingsStore {
     @discardableResult
     func writeConfigFile() throws -> URL {
         var dict: [String: Any] = [
-            "port":                     port,
+            "transport":                transportKind.rawValue,
             "num_threads":              numThreads,
             "silence_rms_threshold":    silenceRmsThreshold,
             "partial_silence_secs":     partialSilenceSecs,
@@ -123,6 +154,12 @@ final class SettingsStore {
             "min_transcribe_secs":      minTranscribeSecs,
             "min_speech_secs":          minSpeechSecs,
         ]
+        switch sidecarEndpoint {
+        case .unix(let path):
+            dict["socket_path"] = path
+        case .loopbackTcp(_, let port):
+            dict["port"] = Int(port)
+        }
         if !modelPath.isEmpty  { dict["model_path"]   = modelPath }
         if !tokensPath.isEmpty { dict["tokens_path"]  = tokensPath }
 

--- a/Sources/Speakboard/SettingsWindowController.swift
+++ b/Sources/Speakboard/SettingsWindowController.swift
@@ -13,7 +13,12 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 
     // MARK: - Form fields
 
-    private let portField          = SettingsWindowController.numberField()
+    private let transportPopup: NSPopUpButton = {
+        let popup = NSPopUpButton()
+        BackendTransportKind.allCases.forEach { popup.addItem(withTitle: $0.displayName) }
+        return popup
+    }()
+    private let endpointField      = SettingsWindowController.endpointField()
     private let threadsField       = SettingsWindowController.numberField()
     private let silenceRmsField    = SettingsWindowController.numberField()
     private let partialField       = SettingsWindowController.numberField()
@@ -130,13 +135,20 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         hotkeyStack.spacing = 8
         hotkeyStack.alignment = .centerY
 
+        transportPopup.target = self
+        transportPopup.action = #selector(transportChanged)
+
         header("Hotkey")
         let hotkeyLbl = NSTextField(labelWithString: "Global shortcut")
         hotkeyLbl.alignment = .right
         grid.addRow(with: [hotkeyLbl, hotkeyStack])
 
         header("Server")
-        row("Port",    field: portField)
+        grid.addRow(with: [
+            NSTextField(labelWithString: "Transport"),
+            transportPopup,
+        ])
+        row("Endpoint", field: endpointField)
         row("Threads", field: threadsField)
 
         header("VAD")
@@ -192,7 +204,16 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         hotkeyDisplayField.stringValue = Self.hotkeyDisplayString(
             keyCode: recordedKeyCode, modifiers: recordedModifiers
         )
-        portField.stringValue          = "\(settings.port)"
+        if let idx = BackendTransportKind.allCases.firstIndex(of: settings.transportKind) {
+            transportPopup.selectItem(at: idx)
+        }
+        switch settings.sidecarEndpoint {
+        case .unix(let path):
+            endpointField.stringValue = path
+        case .loopbackTcp(_, let port):
+            endpointField.stringValue = "\(port)"
+        }
+        applyEndpointFieldStyle()
         threadsField.stringValue       = "\(settings.numThreads)"
         silenceRmsField.stringValue    = format(settings.silenceRmsThreshold)
         partialField.stringValue       = format(settings.partialSilenceSecs)
@@ -210,7 +231,14 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
             settings.hotkeyKeyCode  = Int(recordedKeyCode)
             settings.hotkeyModifiers = Int(recordedModifiers)
         }
-        settings.port                  = Int(portField.stringValue)          ?? SettingsStore.defaultPort
+        settings.transportKind = selectedTransportKind()
+        let endpointValue = endpointField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch settings.transportKind {
+        case .unixDomainSocket:
+            settings.socketPath = endpointValue.isEmpty ? SettingsStore.defaultSocketPath : endpointValue
+        case .loopbackTcp:
+            settings.port = Int(endpointValue) ?? SettingsStore.defaultPort
+        }
         settings.numThreads            = Int(threadsField.stringValue)       ?? SettingsStore.defaultNumThreads
         settings.silenceRmsThreshold   = Double(silenceRmsField.stringValue) ?? SettingsStore.defaultSilenceRmsThreshold
         settings.partialSilenceSecs    = Double(partialField.stringValue)    ?? SettingsStore.defaultPartialSilenceSecs
@@ -238,6 +266,14 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     @objc private func resetDefaults() {
         settings.resetToDefaults()
         loadValues()
+    }
+
+    @objc private func transportChanged() {
+        let trimmed = endpointField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            endpointField.stringValue = defaultEndpointValue(for: selectedTransportKind())
+        }
+        applyEndpointFieldStyle()
     }
 
     // MARK: - Hotkey recorder
@@ -344,6 +380,29 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         v.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(v)) : String(v)
     }
 
+    private func selectedTransportKind() -> BackendTransportKind {
+        let idx = max(0, transportPopup.indexOfSelectedItem)
+        return BackendTransportKind.allCases[idx]
+    }
+
+    private func defaultEndpointValue(for kind: BackendTransportKind) -> String {
+        switch kind {
+        case .unixDomainSocket:
+            return SettingsStore.defaultSocketPath
+        case .loopbackTcp:
+            return String(SettingsStore.defaultPort)
+        }
+    }
+
+    private func applyEndpointFieldStyle() {
+        switch selectedTransportKind() {
+        case .unixDomainSocket:
+            endpointField.placeholderString = SettingsStore.defaultSocketPath
+        case .loopbackTcp:
+            endpointField.placeholderString = String(SettingsStore.defaultPort)
+        }
+    }
+
     private static func numberField() -> NSTextField {
         let f = NSTextField()
         f.placeholderString = "default"
@@ -354,6 +413,12 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private static func pathField() -> NSTextField {
         let f = NSTextField()
         f.placeholderString = "(auto)"
+        f.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        return f
+    }
+
+    private static func endpointField() -> NSTextField {
+        let f = NSTextField()
         f.setContentHuggingPriority(.defaultLow, for: .horizontal)
         return f
     }

--- a/Sources/Speakboard/SidecarManager.swift
+++ b/Sources/Speakboard/SidecarManager.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-// Manages the Rust backend sidecar wrapper and a persistent WebSocket connection to it.
+// Manages the Rust backend sidecar wrapper and a persistent local IPC connection to it.
 //
 // Connection lifecycle:
 //   start() → launch wrapper → connect after 2 s → receive "ready" → isReady = true
 //   Per recording session: beginSession() → sendAudioChunk() × N → sendStop()
-//   → server sends GoldReplace → onFinalResult called → WS closes → reconnect
+//   → server sends GoldReplace → onFinalResult called → connection closes → reconnect
 //   On unexpected disconnect: retry up to maxReconnectAttempts, then restart process.
 
 final class SidecarManager {
 
     // MARK: - Callbacks (set by FloatingPanelController before start())
 
-    /// Called once the WebSocket connection is established and the server sends "ready".
+    /// Called once the transport is established and the server sends "ready".
     var onReady: (() -> Void)?
     /// Called with the latest provisional transcription text during recording.
     var onPartial: ((String) -> Void)?
@@ -28,7 +28,6 @@ final class SidecarManager {
     // MARK: - Config
 
     private let settings: SettingsStore
-    private var port: Int { settings.port }
 
     init(settings: SettingsStore = .shared) {
         self.settings = settings
@@ -42,8 +41,7 @@ final class SidecarManager {
 
     private var process: Process?
     private var processStdinPipe: Pipe?
-    private var wsTask: URLSessionWebSocketTask?
-    private lazy var urlSession = URLSession(configuration: .default)
+    private var transport: FramedSidecarTransport?
 
     private var shouldReconnect = true
     private var reconnectAttempts = 0
@@ -88,8 +86,8 @@ final class SidecarManager {
     func stop() {
         shouldReconnect = false
         reconnectWorkItem?.cancel()
-        wsTask?.cancel(with: .goingAway, reason: nil)
-        wsTask = nil
+        transport?.close()
+        transport = nil
         shutdownProcess()
         isReady = false
     }
@@ -106,10 +104,8 @@ final class SidecarManager {
 
     /// Send raw PCM i16 LE audio chunk to the server. Safe to call from any thread.
     func sendAudioChunk(_ data: Data) {
-        guard isReady, let task = wsTask else { return }
-        task.send(.data(data)) { error in
-            if let error { print("[sidecar] chunk send error: \(error)") }
-        }
+        guard isReady else { return }
+        transport?.sendAudioChunk(data)
     }
 
     /// Signal the server to flush remaining audio and produce the final transcription.
@@ -208,7 +204,7 @@ final class SidecarManager {
                 self?.process = nil
                 self?.processStdinPipe = nil
                 self?.isReady = false
-                self?.wsTask = nil
+                self?.transport = nil
             }
         }
 
@@ -250,16 +246,33 @@ final class SidecarManager {
         return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
     }
 
-    // MARK: - WebSocket
+    // MARK: - Transport
 
     private func connect() {
         guard shouldReconnect else { return }
-        let url = URL(string: "ws://127.0.0.1:\(port)/ws")!
-        let task = urlSession.webSocketTask(with: url)
-        wsTask = task
-        task.resume()
-        receiveLoop()
-        print("[sidecar] connecting to \(url)")
+        let transport = FramedSidecarTransport(endpoint: settings.sidecarEndpoint)
+        self.transport = transport
+
+        transport.onText = { [weak self] text in
+            self?.handleText(text)
+        }
+        transport.onDisconnect = { [weak self] error in
+            guard let self else { return }
+            if !self.sessionStopped, let error {
+                print("[sidecar] transport error: \(error.localizedDescription)")
+            }
+            self.onDisconnected()
+        }
+        transport.connect { [weak self] error in
+            guard let self else { return }
+            if let error {
+                print("[sidecar] connect failed: \(error.localizedDescription)")
+                return
+            }
+            print("[sidecar] connected to \(transport.endpointDescription)")
+            self.sendText(#"{"type":"start"}"#)
+        }
+        print("[sidecar] connecting to \(transport.endpointDescription)")
     }
 
     private func scheduleConnect(delay: TimeInterval) {
@@ -267,29 +280,6 @@ final class SidecarManager {
         let item = DispatchWorkItem { [weak self] in self?.connect() }
         reconnectWorkItem = item
         DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
-    }
-
-    private func receiveLoop() {
-        wsTask?.receive { [weak self] result in
-            guard let self else { return }
-            switch result {
-            case .success(let message):
-                let text: String?
-                switch message {
-                case .string(let s): text = s
-                case .data(let d):   text = String(data: d, encoding: .utf8)
-                @unknown default:    text = nil
-                }
-                if let text { DispatchQueue.main.async { self.handleText(text) } }
-                self.receiveLoop()
-            case .failure(let error):
-                // Suppress the log for expected disconnects (server closed after Stop).
-                if !self.sessionStopped {
-                    print("[sidecar] WS receive error: \(error.localizedDescription)")
-                }
-                DispatchQueue.main.async { self.onDisconnected() }
-            }
-        }
     }
 
     private func handleText(_ text: String) {
@@ -337,7 +327,7 @@ final class SidecarManager {
     private func onDisconnected() {
         guard shouldReconnect else { return }
         isReady = false
-        wsTask = nil
+        transport = nil
 
         // If a session was stopped but no GoldReplace arrived before disconnect, deliver nil.
         if sessionStopped && !finalResultDelivered {
@@ -390,9 +380,6 @@ final class SidecarManager {
     }
 
     private func sendText(_ text: String) {
-        guard let task = wsTask else { return }
-        task.send(.string(text)) { error in
-            if let error { print("[sidecar] text send error: \(error)") }
-        }
+        transport?.sendJSONText(text)
     }
 }

--- a/Sources/Speakboard/SidecarTransport.swift
+++ b/Sources/Speakboard/SidecarTransport.swift
@@ -1,0 +1,228 @@
+import Foundation
+import Network
+
+enum BackendTransportKind: String, CaseIterable {
+    case unixDomainSocket = "unix_domain_socket"
+    case loopbackTcp = "loopback_tcp"
+
+    var displayName: String {
+        switch self {
+        case .unixDomainSocket:
+            return "Unix Domain Socket"
+        case .loopbackTcp:
+            return "Loopback TCP"
+        }
+    }
+}
+
+enum SidecarEndpoint: Equatable {
+    case unix(path: String)
+    case loopbackTcp(host: String, port: UInt16)
+
+    var transportKind: BackendTransportKind {
+        switch self {
+        case .unix:
+            return .unixDomainSocket
+        case .loopbackTcp:
+            return .loopbackTcp
+        }
+    }
+
+    var endpointValue: String {
+        switch self {
+        case .unix(let path):
+            return path
+        case .loopbackTcp(_, let port):
+            return String(port)
+        }
+    }
+
+    var logDescription: String {
+        switch self {
+        case .unix(let path):
+            return "unix://\(path)"
+        case .loopbackTcp(let host, let port):
+            return "tcp://\(host):\(port)"
+        }
+    }
+}
+
+final class FramedSidecarTransport {
+    private enum FrameType {
+        static let json: UInt8 = 1
+        static let audio: UInt8 = 2
+    }
+
+    private let endpoint: SidecarEndpoint
+    private let queue = DispatchQueue(label: "speakboard.sidecar.transport")
+
+    private var connection: NWConnection?
+    private var pendingConnectCompletion: ((Error?) -> Void)?
+    private var receiveBuffer = Data()
+    private var didBecomeReady = false
+    private var didNotifyDisconnect = false
+
+    var onText: ((String) -> Void)?
+    var onDisconnect: ((Error?) -> Void)?
+
+    init(endpoint: SidecarEndpoint) {
+        self.endpoint = endpoint
+    }
+
+    var endpointDescription: String {
+        endpoint.logDescription
+    }
+
+    func connect(completion: @escaping (Error?) -> Void) {
+        queue.async {
+            self.pendingConnectCompletion = completion
+            self.receiveBuffer.removeAll(keepingCapacity: true)
+            self.didBecomeReady = false
+            self.didNotifyDisconnect = false
+
+            let connection = self.makeConnection()
+            self.connection = connection
+            connection.stateUpdateHandler = { [weak self] state in
+                self?.handleStateUpdate(state)
+            }
+            connection.start(queue: self.queue)
+        }
+    }
+
+    func close() {
+        queue.async {
+            self.pendingConnectCompletion = nil
+            self.receiveBuffer.removeAll(keepingCapacity: false)
+            self.didBecomeReady = false
+            self.connection?.cancel()
+            self.connection = nil
+        }
+    }
+
+    func sendJSONText(_ text: String) {
+        guard let data = text.data(using: .utf8) else { return }
+        sendFrame(type: FrameType.json, payload: data)
+    }
+
+    func sendAudioChunk(_ data: Data) {
+        sendFrame(type: FrameType.audio, payload: data)
+    }
+
+    private func makeConnection() -> NWConnection {
+        switch endpoint {
+        case .unix(let path):
+            return NWConnection(to: .unix(path: path), using: .tcp)
+        case .loopbackTcp(let host, let port):
+            return NWConnection(
+                host: NWEndpoint.Host(host),
+                port: NWEndpoint.Port(rawValue: port)!,
+                using: .tcp
+            )
+        }
+    }
+
+    private func handleStateUpdate(_ state: NWConnection.State) {
+        switch state {
+        case .ready:
+            guard !didBecomeReady else { return }
+            didBecomeReady = true
+            let completion = pendingConnectCompletion
+            pendingConnectCompletion = nil
+            DispatchQueue.main.async { completion?(nil) }
+            receiveNextChunk()
+
+        case .failed(let error):
+            let completion = pendingConnectCompletion
+            pendingConnectCompletion = nil
+            DispatchQueue.main.async { completion?(error) }
+            handleDisconnect(error)
+
+        case .cancelled:
+            let completion = pendingConnectCompletion
+            pendingConnectCompletion = nil
+            DispatchQueue.main.async { completion?(nil) }
+            handleDisconnect(nil)
+
+        default:
+            break
+        }
+    }
+
+    private func receiveNextChunk() {
+        connection?.receive(
+            minimumIncompleteLength: 1,
+            maximumLength: 64 * 1024
+        ) { [weak self] data, _, isComplete, error in
+            guard let self else { return }
+            if let data, !data.isEmpty {
+                self.receiveBuffer.append(data)
+                self.drainFrames()
+            }
+            if let error {
+                self.handleDisconnect(error)
+                return
+            }
+            if isComplete {
+                self.handleDisconnect(nil)
+                return
+            }
+            self.receiveNextChunk()
+        }
+    }
+
+    private func drainFrames() {
+        while receiveBuffer.count >= 5 {
+            let payloadLength =
+                (UInt32(receiveBuffer[1]) << 24) |
+                (UInt32(receiveBuffer[2]) << 16) |
+                (UInt32(receiveBuffer[3]) << 8) |
+                UInt32(receiveBuffer[4])
+            let frameLength = 5 + Int(payloadLength)
+            guard receiveBuffer.count >= frameLength else { return }
+
+            let frameType = receiveBuffer[0]
+            let payload = receiveBuffer.subdata(in: 5..<frameLength)
+            receiveBuffer.removeSubrange(0..<frameLength)
+
+            guard frameType == FrameType.json,
+                  let text = String(data: payload, encoding: .utf8) else {
+                continue
+            }
+            DispatchQueue.main.async { self.onText?(text) }
+        }
+    }
+
+    private func sendFrame(type: UInt8, payload: Data) {
+        queue.async {
+            guard let connection = self.connection else { return }
+
+            var frame = Data([type])
+            var length = UInt32(payload.count).bigEndian
+            withUnsafeBytes(of: &length) { rawBuffer in
+                frame.append(contentsOf: rawBuffer)
+            }
+            frame.append(payload)
+
+            connection.send(
+                content: frame,
+                contentContext: .defaultMessage,
+                isComplete: false,
+                completion: .contentProcessed { error in
+                    if let error {
+                        self.handleDisconnect(error)
+                    }
+                }
+            )
+        }
+    }
+
+    private func handleDisconnect(_ error: Error?) {
+        guard !didNotifyDisconnect else { return }
+        didNotifyDisconnect = true
+        didBecomeReady = false
+        pendingConnectCompletion = nil
+        receiveBuffer.removeAll(keepingCapacity: false)
+        connection = nil
+        DispatchQueue.main.async { self.onDisconnect?(error) }
+    }
+}


### PR DESCRIPTION
## Summary
- switch the Swift sidecar client from a fixed WebSocket connection to a transport-aware framed IPC transport backed by Network.framework
- expose transport and endpoint settings so the app can default to Unix domain sockets while keeping loopback TCP available as a compatibility path
- update the backend submodule to the merged local IPC implementation now on backend `master`

## Test plan
- [x] `swift build`
- [x] backend PR merged and submodule updated to backend `master`
- [x] manual macOS smoke test with the app talking to the merged backend over the default Unix socket transport

Made with [Cursor](https://cursor.com)