### PR TITLE
feat: add inline dictation mode with floating mic button

### DIFF
--- a/Sources/Speakboard/AppDelegate.swift
+++ b/Sources/Speakboard/AppDelegate.swift
@@ -31,18 +31,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         inlineDictation.onStateChange = { [weak self] active in
             self?.micButtonPanel.setRecording(active)
         }
-        micButtonPanel.show()
 
-        // Global hotkey: skip if inline dictation is currently active.
+        // Global hotkey (used for normal panel dictation).
         hotkey = GlobalHotkeyManager(
             keyCode:   UInt32(SettingsStore.shared.hotkeyKeyCode),
             modifiers: UInt32(SettingsStore.shared.hotkeyModifiers),
-            onPress:   { [weak self] in
-                guard !(self?.inlineDictation.isActive ?? false) else { return }
-                self?.panel.hotkeyPressed()
-            },
+            onPress:   { [weak self] in self?.panel.hotkeyPressed() },
             onRelease: { [weak self] in self?.panel.hotkeyReleased() }
         )
+
+        applyDictationMode()
 
         settingsWindow.onSaveRestart = { [weak self] in
             guard let self else { return }
@@ -53,6 +51,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             )
             self.panel.applySettings()
             self.inlineDictation.applySettings()
+            self.applyDictationMode()
         }
         statusBar.onSettings = { [weak self] in
             self?.settingsWindow.showSettings()
@@ -60,6 +59,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         sidecar.start()
         panel.sidecar = sidecar
+    }
+
+    /// Show/hide mic button and enable/disable hotkey based on the current setting.
+    private func applyDictationMode() {
+        let inline = SettingsStore.shared.inlineDictationEnabled
+        print("[app] applyDictationMode: inlineDictationEnabled=\(inline)")
+        if inline {
+            micButtonPanel.show()
+            hotkey.unregister()
+            print("[app]   → mic button shown, hotkey unregistered")
+        } else {
+            micButtonPanel.hide()
+            hotkey.update(
+                keyCode:   UInt32(SettingsStore.shared.hotkeyKeyCode),
+                modifiers: UInt32(SettingsStore.shared.hotkeyModifiers)
+            )
+            print("[app]   → mic button hidden, hotkey registered")
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/Sources/Speakboard/AppDelegate.swift
+++ b/Sources/Speakboard/AppDelegate.swift
@@ -51,6 +51,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 keyCode:   UInt32(SettingsStore.shared.hotkeyKeyCode),
                 modifiers: UInt32(SettingsStore.shared.hotkeyModifiers)
             )
+            self.panel.applySettings()
+            self.inlineDictation.applySettings()
         }
         statusBar.onSettings = { [weak self] in
             self?.settingsWindow.showSettings()

--- a/Sources/Speakboard/AppDelegate.swift
+++ b/Sources/Speakboard/AppDelegate.swift
@@ -6,6 +6,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hotkey: GlobalHotkeyManager!
     private var sidecar: SidecarManager!
     private var settingsWindow: SettingsWindowController!
+    private var inlineDictation: InlineDictationController!
+    private var micButtonPanel: MicButtonPanel!
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         panel    = FloatingPanelController()
@@ -13,10 +15,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         sidecar  = SidecarManager(settings: .shared)
         settingsWindow = SettingsWindowController(settings: .shared)
 
+        // Inline dictation (mic button — hold to dictate directly at cursor).
+        inlineDictation = InlineDictationController()
+        inlineDictation.sidecar = sidecar
+        inlineDictation.panel   = panel
+
+        micButtonPanel = MicButtonPanel()
+        micButtonPanel.currentMode = inlineDictation.mode
+        micButtonPanel.onPress   = { [weak self] in self?.inlineDictation.handlePress() }
+        micButtonPanel.onRelease = { [weak self] in self?.inlineDictation.handleRelease() }
+        micButtonPanel.onTap     = { [weak self] in self?.inlineDictation.handleTap() }
+        micButtonPanel.onModeChange = { [weak self] mode in
+            self?.inlineDictation.mode = mode
+        }
+        inlineDictation.onStateChange = { [weak self] active in
+            self?.micButtonPanel.setRecording(active)
+        }
+        micButtonPanel.show()
+
+        // Global hotkey: skip if inline dictation is currently active.
         hotkey = GlobalHotkeyManager(
             keyCode:   UInt32(SettingsStore.shared.hotkeyKeyCode),
             modifiers: UInt32(SettingsStore.shared.hotkeyModifiers),
-            onPress:   { [weak self] in self?.panel.hotkeyPressed() },
+            onPress:   { [weak self] in
+                guard !(self?.inlineDictation.isActive ?? false) else { return }
+                self?.panel.hotkeyPressed()
+            },
             onRelease: { [weak self] in self?.panel.hotkeyReleased() }
         )
 

--- a/Sources/Speakboard/AudioRecorder.swift
+++ b/Sources/Speakboard/AudioRecorder.swift
@@ -74,6 +74,13 @@ final class AudioRecorder {
         }
     }
 
+    /// Tear down the warmed-up engine when low-latency startup is not needed.
+    func coolDown() {
+        guard !isRecording else { return }
+        teardownEngine()
+        audioChainDirty = true
+    }
+
     /// Request microphone permission if needed, then start capturing audio.
     func startRecording(completion: @escaping (Error?) -> Void) {
         guard !isRecording else { completion(nil); return }

--- a/Sources/Speakboard/AudioRecorder.swift
+++ b/Sources/Speakboard/AudioRecorder.swift
@@ -3,6 +3,10 @@ import CoreAudio
 
 // Streams real-time PCM i16 LE audio at 16 kHz mono to the provided onChunk callback.
 // Each call to onChunk delivers a Data blob containing raw 16-bit signed little-endian samples.
+//
+// LATENCY NOTE: Call warmUp() once after mic permission is granted to pre-start the
+// AVAudioEngine.  Subsequent startRecording() calls open a gate on the already-running
+// tap instead of rebuilding the engine chain, eliminating the ~200 ms startup delay.
 final class AudioRecorder {
 
     private struct InputFormatKey: Equatable {
@@ -53,6 +57,23 @@ final class AudioRecorder {
 
     // MARK: - Public
 
+    /// Pre-start the audio engine so the first startRecording() is instant.
+    /// Safe to call multiple times; no-op if already warm.
+    func warmUp() {
+        AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
+            guard granted else { return }
+            DispatchQueue.main.async {
+                guard let self else { return }
+                guard self.engine == nil || self.audioChainDirty else { return }
+                do {
+                    try self.buildAndStartEngine()
+                } catch {
+                    print("[recorder] warmUp failed: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
     /// Request microphone permission if needed, then start capturing audio.
     func startRecording(completion: @escaping (Error?) -> Void) {
         guard !isRecording else { completion(nil); return }
@@ -64,8 +85,14 @@ final class AudioRecorder {
                                       userInfo: [NSLocalizedDescriptionKey: "Microphone access denied."]))
                     return
                 }
+                guard let self else { return }
                 do {
-                    try self?.doStart()
+                    // Rebuild only if the chain is dirty or engine was never started.
+                    if self.engine == nil || self.audioChainDirty || !(self.engine?.isRunning ?? false) {
+                        try self.buildAndStartEngine()
+                    }
+                    // Open the gate — tap is already running.
+                    self.isRecording = true
                     completion(nil)
                 } catch {
                     completion(error)
@@ -74,37 +101,46 @@ final class AudioRecorder {
         }
     }
 
-    /// Stop capturing. Any in-flight onChunk call may still complete after this returns.
+    /// Stop capturing. The engine keeps running so the next startRecording() is instant.
     func stopRecording() {
         guard isRecording else { return }
         isRecording = false
-        engine?.inputNode.removeTap(onBus: 0)
-        engine?.stop()
-        converter = nil
-        converterInputFormat = nil
-
+        // Do NOT remove the tap or stop the engine — keep it warm for the next session.
+        // If the audio chain became dirty while recording, rebuild it now.
         if audioChainDirty {
             teardownEngine()
+            // Re-warm immediately so it is ready for the next session.
+            do { try buildAndStartEngine() } catch {
+                print("[recorder] re-warm after dirty stop failed: \(error.localizedDescription)")
+            }
         }
     }
 
     // MARK: - Private
 
-    private func doStart() throws {
-        rebuildEngineIfNeeded()
+    /// Build (or rebuild) the engine, install the tap, and start the engine.
+    private func buildAndStartEngine() throws {
+        teardownEngine()
 
-        guard let engine else {
-            throw NSError(domain: "AudioRecorder", code: 2,
-                          userInfo: [NSLocalizedDescriptionKey: "Cannot create audio engine."])
+        let engine = AVAudioEngine()
+        self.engine = engine
+        audioChainDirty = false
+
+        engineConfigObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: engine,
+            queue: .main
+        ) { [weak self] _ in
+            self?.markAudioChainDirty()
         }
 
         let inputNode = engine.inputNode
-        inputNode.removeTap(onBus: 0)
 
-        // Let AVAudioEngine pick the bus format so a device switch does not leave us
-        // installing a tap with a stale format from the previous input route.
+        // format: nil lets AVAudioEngine use the native hardware format,
+        // avoiding tap-format-mismatch crashes with Bluetooth devices.
         inputNode.installTap(onBus: 0, bufferSize: 4096, format: nil) { [weak self] inBuf, _ in
-            guard let self, let conv = self.converter(for: inBuf.format) else { return }
+            guard let self, self.isRecording,       // gate: only forward when active
+                  let conv = self.converter(for: inBuf.format) else { return }
 
             let ratio = self.outputFormat.sampleRate / inBuf.format.sampleRate
             let outCapacity = AVAudioFrameCount(Double(inBuf.frameLength) * ratio + 1)
@@ -130,7 +166,6 @@ final class AudioRecorder {
         }
 
         try engine.start()
-        isRecording = true
     }
 
     private func converter(for inputFormat: AVAudioFormat) -> AVAudioConverter? {
@@ -138,32 +173,13 @@ final class AudioRecorder {
         if converterInputFormat == key, let converter {
             return converter
         }
-
         guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
             print("[recorder] cannot create audio converter for input format: \(inputFormat)")
             return nil
         }
-
         self.converter = converter
         converterInputFormat = key
         return converter
-    }
-
-    private func rebuildEngineIfNeeded() {
-        guard engine == nil || audioChainDirty else { return }
-        teardownEngine()
-
-        let engine = AVAudioEngine()
-        self.engine = engine
-        audioChainDirty = false
-
-        engineConfigObserver = NotificationCenter.default.addObserver(
-            forName: .AVAudioEngineConfigurationChange,
-            object: engine,
-            queue: .main
-        ) { [weak self] _ in
-            self?.markAudioChainDirty()
-        }
     }
 
     private func teardownEngine() {

--- a/Sources/Speakboard/DictationMode.swift
+++ b/Sources/Speakboard/DictationMode.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// How the mic button triggers dictation.
+enum DictationMode: Equatable {
+    /// Hold the button to record; release to stop. (default)
+    case hold
+    /// First click starts recording, second click stops it.
+    case toggle
+    /// Click to start; automatically stops after `silenceDelay` seconds
+    /// with no new speech detected from the backend.
+    case autoStop(silenceDelay: Double)
+
+    // MARK: - UserDefaults persistence
+
+    private static let key = "dictationMode"
+
+    static func load() -> DictationMode {
+        guard let raw = UserDefaults.standard.string(forKey: key) else { return .hold }
+        switch raw {
+        case "hold":   return .hold
+        case "toggle": return .toggle
+        default:
+            if raw.hasPrefix("autoStop:"),
+               let d = Double(raw.dropFirst("autoStop:".count)) {
+                return .autoStop(silenceDelay: d)
+            }
+            return .hold
+        }
+    }
+
+    func save() {
+        let raw: String
+        switch self {
+        case .hold:               raw = "hold"
+        case .toggle:             raw = "toggle"
+        case .autoStop(let d):    raw = "autoStop:\(d)"
+        }
+        UserDefaults.standard.set(raw, forKey: DictationMode.key)
+    }
+
+    // MARK: - Display
+
+    var menuTitle: String {
+        switch self {
+        case .hold:               return "Hold to Speak"
+        case .toggle:             return "Click to Stop"
+        case .autoStop(let d):    return "Auto-stop \(formatDelay(d))"
+        }
+    }
+}
+
+private func formatDelay(_ d: Double) -> String {
+    let ms = Int(d * 1000)
+    return ms % 1000 == 0 ? "\(Int(d))s" : "\(ms)ms"
+}

--- a/Sources/Speakboard/FloatingPanelController.swift
+++ b/Sources/Speakboard/FloatingPanelController.swift
@@ -14,6 +14,8 @@ enum PanelState {
 
 final class FloatingPanelController: NSObject {
 
+    private let settings: SettingsStore
+
     // Text written to the clipboard on Enter.  nil means no valid text to paste.
     var pasteText: String? = nil
 
@@ -44,13 +46,15 @@ final class FloatingPanelController: NSObject {
 
     // MARK: - Init
 
-    override init() {
+    init(settings: SettingsStore = .shared) {
+        self.settings = settings
         super.init()
         // Wire recorder's real-time chunks directly to the sidecar transport.
         // The closure is set once; it reads sidecar lazily at call time.
         recorder.onChunk = { [weak self] data in
             self?.sidecar?.sendAudioChunk(data)
         }
+        applySettings()
     }
 
     // MARK: - SidecarManager callbacks
@@ -59,6 +63,14 @@ final class FloatingPanelController: NSObject {
     /// Called by InlineDictationController after it finishes a session.
     func reattachSidecarCallbacks() {
         setupSidecarCallbacks()
+    }
+
+    func applySettings() {
+        if settings.inlineWarmUpEnabled {
+            recorder.warmUp()
+        } else if !recorder.isRecording {
+            recorder.coolDown()
+        }
     }
 
     private func setupSidecarCallbacks() {
@@ -98,7 +110,7 @@ final class FloatingPanelController: NSObject {
         pressTime = Date()
 
         // Discard any in-flight recording from a previous session.
-        recorder.stopRecording()
+        stopRecorderSession()
 
         if window.isVisible {
             centerOnMouseScreen()
@@ -152,7 +164,7 @@ final class FloatingPanelController: NSObject {
         state = .transcribing
         contentView?.enterTranscribingState()
 
-        recorder.stopRecording()      // stop sending chunks
+        stopRecorderSession()         // stop sending chunks
         sidecar?.sendStop()           // signal backend to flush and transcribe
         // handleFinalResult() will be called when the server responds.
     }
@@ -176,7 +188,7 @@ final class FloatingPanelController: NSObject {
     func hide() {
         holdWorkItem?.cancel()
         holdWorkItem = nil
-        recorder.stopRecording()
+        stopRecorderSession()
         switch state {
         case .recording:
             // Cancel the current sidecar session without triggering transcription.
@@ -240,6 +252,13 @@ final class FloatingPanelController: NSObject {
             contentView?.enterResultState(text: text, pasteable: true)
         } else {
             contentView?.enterResultState(text: errorMessage ?? "Transcription failed.", pasteable: false)
+        }
+    }
+
+    private func stopRecorderSession() {
+        recorder.stopRecording()
+        if !settings.inlineWarmUpEnabled {
+            recorder.coolDown()
         }
     }
 

--- a/Sources/Speakboard/FloatingPanelController.swift
+++ b/Sources/Speakboard/FloatingPanelController.swift
@@ -55,6 +55,12 @@ final class FloatingPanelController: NSObject {
 
     // MARK: - SidecarManager callbacks
 
+    /// Re-attach the panel's own callbacks on the shared sidecar.
+    /// Called by InlineDictationController after it finishes a session.
+    func reattachSidecarCallbacks() {
+        setupSidecarCallbacks()
+    }
+
     private func setupSidecarCallbacks() {
         sidecar?.onPartial = { [weak self] text in
             DispatchQueue.main.async { self?.handleLiveText(text) }

--- a/Sources/Speakboard/GlobalHotkeyManager.swift
+++ b/Sources/Speakboard/GlobalHotkeyManager.swift
@@ -41,6 +41,11 @@ final class GlobalHotkeyManager {
         register(keyCode: keyCode, modifiers: modifiers)
     }
 
+    /// Unregister the hotkey so it stops firing.
+    func unregister() {
+        if let r = hotKeyRef { UnregisterEventHotKey(r); hotKeyRef = nil }
+    }
+
     // MARK: - Private
 
     private func installHandler() {

--- a/Sources/Speakboard/HighlightOverlay.swift
+++ b/Sources/Speakboard/HighlightOverlay.swift
@@ -1,0 +1,108 @@
+import AppKit
+
+/// Draws a coloured ring around the frontmost window while inline dictation is active,
+/// so the user can clearly see which window will receive the transcribed text.
+///
+/// The overlay is completely transparent to mouse events and never steals focus.
+final class HighlightOverlay {
+
+    private var panel: NSPanel?
+
+    // MARK: - Public
+
+    func show() {
+        guard let frame = focusedWindowFrame() else { return }
+        let p = makePanel(frame: frame)
+        p.alphaValue = 0
+        p.orderFrontRegardless()
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.15
+            p.animator().alphaValue = 1
+        }
+        panel = p
+    }
+
+    func hide() {
+        guard let p = panel else { return }
+        panel = nil
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = 0.2
+            p.animator().alphaValue = 0
+        }, completionHandler: {
+            p.orderOut(nil)
+        })
+    }
+
+    // MARK: - Panel construction
+
+    private func makePanel(frame: NSRect) -> NSPanel {
+        let p = NSPanel(
+            contentRect: frame,
+            styleMask: [.nonactivatingPanel, .borderless],
+            backing: .buffered,
+            defer: false
+        )
+        p.level             = .floating
+        p.backgroundColor   = .clear
+        p.isOpaque          = false
+        p.hasShadow         = false
+        p.ignoresMouseEvents = true
+        p.isReleasedWhenClosed = false
+        p.collectionBehavior   = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        p.contentView = HighlightView(frame: NSRect(origin: .zero, size: frame.size))
+        return p
+    }
+
+    // MARK: - AX window lookup
+
+    private func focusedWindowFrame() -> NSRect? {
+        guard let app = NSWorkspace.shared.frontmostApplication else { return nil }
+        // Don't highlight our own panel.
+        if app.bundleIdentifier == Bundle.main.bundleIdentifier { return nil }
+
+        let axApp = AXUIElementCreateApplication(app.processIdentifier)
+
+        var windowRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            axApp, "AXFocusedWindow" as CFString, &windowRef
+        ) == .success, let windowRef else { return nil }
+
+        var frameVal: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            // swiftlint:disable:next force_cast
+            windowRef as! AXUIElement, "AXFrame" as CFString, &frameVal
+        ) == .success, let frameVal else { return nil }
+
+        var axRect = CGRect.zero
+        // swiftlint:disable:next force_cast
+        guard AXValueGetValue(frameVal as! AXValue, .cgRect, &axRect) else { return nil }
+
+        // AX uses a top-left origin (Y increases downward) relative to the primary
+        // screen.  AppKit uses a bottom-left origin (Y increases upward).
+        let mainH = NSScreen.screens[0].frame.height
+        return NSRect(
+            x: axRect.origin.x,
+            y: mainH - axRect.origin.y - axRect.height,
+            width:  axRect.width,
+            height: axRect.height
+        )
+    }
+}
+
+// MARK: - Highlight ring view
+
+private final class HighlightView: NSView {
+
+    override var isFlipped: Bool { false }
+
+    override func draw(_ dirtyRect: NSRect) {
+        let inset: CGFloat  = 1.5
+        let radius: CGFloat = 12
+        let rect = bounds.insetBy(dx: inset, dy: inset)
+
+        let path = NSBezierPath(roundedRect: rect, xRadius: radius, yRadius: radius)
+        path.lineWidth = 3.5
+        NSColor.systemBlue.withAlphaComponent(0.85).setStroke()
+        path.stroke()
+    }
+}

--- a/Sources/Speakboard/InlineDictationController.swift
+++ b/Sources/Speakboard/InlineDictationController.swift
@@ -34,8 +34,6 @@ final class InlineDictationController {
 
     private let recorder  = AudioRecorder()
     private let highlight = HighlightOverlay()
-    /// Number of grapheme clusters currently typed at cursor (pending partial).
-    private var insertedCount = 0
     /// Silence auto-stop timer (only used in .autoStop mode).
     private var silenceTimer: DispatchWorkItem?
 
@@ -101,17 +99,18 @@ final class InlineDictationController {
         }
 
         isActive = true
-        insertedCount = 0
         highlight.show()
+        print("[inline] beginDictation: setting up yolo callbacks (onPartial=nil, onGoldUpdate=nil, onCommit=set)")
 
-        // Take over SidecarManager callbacks for inline mode.
-        sidecar.onPartial = { [weak self] text in
-            self?.updateInline(text)
-        }
-        sidecar.onGoldUpdate = { [weak self] text in
-            self?.updateInline(text)
+        // Take over SidecarManager callbacks for yolo (append-only) mode.
+        sidecar.onPartial = nil
+        sidecar.onGoldUpdate = nil
+        sidecar.onCommit = { [weak self] text in
+            print("[inline] onCommit received: \"\(text)\"")
+            self?.appendCommit(text)
         }
         sidecar.onFinalResult = { [weak self] text in
+            print("[inline] onFinalResult received: \"\(text ?? "(nil)")\"")
             self?.finalize(text)
         }
 
@@ -135,7 +134,9 @@ final class InlineDictationController {
         // finalize() is called asynchronously via onFinalResult.
     }
 
-    /// Cancel without producing a result; removes any partial text already typed.
+    /// Cancel without producing a result. Already committed text stays in place
+    /// (yolo mode is append-only — we cannot safely backspace committed text
+    /// because the user may have switched windows).
     func cancel() {
         guard isActive else { return }
         cancelSilenceTimer()
@@ -145,10 +146,6 @@ final class InlineDictationController {
             recorder.coolDown()
         }
         sidecar?.cancelSession()
-        if insertedCount > 0 {
-            sendBackspaces(insertedCount)
-            insertedCount = 0
-        }
         finish()
     }
 
@@ -167,28 +164,23 @@ final class InlineDictationController {
         silenceTimer = nil
     }
 
-    // MARK: - Private — text update
+    // MARK: - Private — text update (yolo / append-only)
 
-    private func updateInline(_ newText: String) {
+    /// Backend committed a completed utterance — just append it at the cursor.
+    private func appendCommit(_ text: String) {
         guard isActive else { return }
-        // Backend sent a speech update — reset the silence countdown.
         resetSilenceTimer()
-        let newCount = newText.count   // grapheme clusters == visual cursor positions
-        sendBackspaces(insertedCount)
-        if newCount > 0 { typeString(newText) }
-        insertedCount = newCount
+        typeString(text)
     }
 
+    /// Session ended. In yolo mode the backend flushes the last utterance as a
+    /// final commit, so `text` here is the full accumulated session text. We
+    /// don't need to retype it — individual commits already typed everything.
     private func finalize(_ text: String?) {
         cancelSilenceTimer()
         defer { if !isActive { panel?.reattachSidecarCallbacks() } }
         guard isActive else { return }
         isActive = false
-        sendBackspaces(insertedCount)
-        insertedCount = 0
-        if let text, !text.isEmpty {
-            typeString(text)
-        }
         finish()
     }
 
@@ -199,18 +191,6 @@ final class InlineDictationController {
     }
 
     // MARK: - Private — CGEvent helpers
-
-    /// Send `count` Delete (⌫) key events to the frontmost app.
-    private func sendBackspaces(_ count: Int) {
-        guard count > 0 else { return }
-        let src = CGEventSource(stateID: .combinedSessionState)
-        for _ in 0..<count {
-            let dn = CGEvent(keyboardEventSource: src, virtualKey: 51, keyDown: true)
-            let up = CGEvent(keyboardEventSource: src, virtualKey: 51, keyDown: false)
-            dn?.post(tap: .cgSessionEventTap)
-            up?.post(tap: .cgSessionEventTap)
-        }
-    }
 
     /// Type `text` at the current cursor position using a single Unicode keyboard event.
     private func typeString(_ text: String) {

--- a/Sources/Speakboard/InlineDictationController.swift
+++ b/Sources/Speakboard/InlineDictationController.swift
@@ -1,0 +1,212 @@
+import AppKit
+
+// InlineDictationController — "hold-to-dictate" mode that types transcription
+// text directly at the cursor position in the frontmost app.
+//
+// Supports three DictationModes (see DictationMode.swift):
+//   .hold      — hold button → record, release → stop  (default)
+//   .toggle    — first click starts, second click stops
+//   .autoStop  — click to start; silence timer calls endDictation() automatically
+//
+// While active the controller temporarily replaces FloatingPanelController's
+// callbacks on the shared SidecarManager. On finish/cancel it restores the
+// panel callbacks via panel.reattachSidecarCallbacks().
+//
+// THREADING: all public methods and callbacks must be called on the main thread.
+
+final class InlineDictationController {
+
+    // Injected by AppDelegate.
+    weak var sidecar: SidecarManager?
+    weak var panel: FloatingPanelController?
+
+    /// Fired when active state changes (true = recording, false = idle/finished).
+    var onStateChange: ((Bool) -> Void)?
+
+    /// Current trigger mode. Persisted to UserDefaults automatically on set.
+    var mode: DictationMode = DictationMode.load() {
+        didSet { mode.save() }
+    }
+
+    private(set) var isActive = false
+
+    private let recorder  = AudioRecorder()
+    private let highlight = HighlightOverlay()
+    /// Number of grapheme clusters currently typed at cursor (pending partial).
+    private var insertedCount = 0
+    /// Silence auto-stop timer (only used in .autoStop mode).
+    private var silenceTimer: DispatchWorkItem?
+
+    // MARK: - Init
+
+    init() {
+        recorder.onChunk = { [weak self] data in
+            self?.sidecar?.sendAudioChunk(data)
+        }
+        // Pre-warm the audio engine so the first startRecording() is instant.
+        recorder.warmUp()
+    }
+
+    // MARK: - Public
+
+    var isReady: Bool { sidecar?.isReady == true }
+
+    // MARK: Button event handlers (called by AppDelegate)
+
+    /// Called on mouseDown. Starts recording only in .hold mode.
+    func handlePress() {
+        if case .hold = mode { beginDictation() }
+    }
+
+    /// Called on mouseUp. Stops recording only in .hold mode.
+    func handleRelease() {
+        if case .hold = mode { endDictation() }
+    }
+
+    /// Called on a tap (mouseUp without drag). Handles .toggle and .autoStop.
+    func handleTap() {
+        switch mode {
+        case .hold:
+            break   // handled entirely by handlePress/handleRelease
+        case .toggle:
+            if isActive { endDictation() } else { beginDictation() }
+        case .autoStop:
+            if isActive { endDictation() } else { beginDictation() }
+        }
+    }
+
+    // MARK: Core dictation lifecycle
+
+    /// Start a dictation session. No-op if already active or sidecar not ready.
+    func beginDictation() {
+        guard !isActive else { return }
+        guard let sidecar, sidecar.isReady else {
+            print("[inline] sidecar not ready — skipping")
+            return
+        }
+        guard AXIsProcessTrusted() else {
+            let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true]
+            AXIsProcessTrustedWithOptions(opts as CFDictionary)
+            return
+        }
+
+        isActive = true
+        insertedCount = 0
+        highlight.show()
+
+        // Take over SidecarManager callbacks for inline mode.
+        sidecar.onPartial = { [weak self] text in
+            self?.updateInline(text)
+        }
+        sidecar.onGoldUpdate = { [weak self] text in
+            self?.updateInline(text)
+        }
+        sidecar.onFinalResult = { [weak self] text in
+            self?.finalize(text)
+        }
+
+        sidecar.beginSession()
+        recorder.startRecording { error in
+            if let error { print("[inline] recorder error: \(error.localizedDescription)") }
+        }
+        onStateChange?(true)
+        // Silence timer starts only after first speech is detected (in updateInline).
+    }
+
+    /// Stop recording and wait for the final transcription.
+    func endDictation() {
+        guard isActive else { return }
+        cancelSilenceTimer()
+        recorder.stopRecording()
+        sidecar?.sendStop()
+        // finalize() is called asynchronously via onFinalResult.
+    }
+
+    /// Cancel without producing a result; removes any partial text already typed.
+    func cancel() {
+        guard isActive else { return }
+        cancelSilenceTimer()
+        isActive = false
+        recorder.stopRecording()
+        sidecar?.cancelSession()
+        if insertedCount > 0 {
+            sendBackspaces(insertedCount)
+            insertedCount = 0
+        }
+        finish()
+    }
+
+    // MARK: - Private — silence timer
+
+    private func resetSilenceTimer() {
+        guard case .autoStop(let delay) = mode else { return }
+        silenceTimer?.cancel()
+        let item = DispatchWorkItem { [weak self] in self?.endDictation() }
+        silenceTimer = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
+    }
+
+    private func cancelSilenceTimer() {
+        silenceTimer?.cancel()
+        silenceTimer = nil
+    }
+
+    // MARK: - Private — text update
+
+    private func updateInline(_ newText: String) {
+        guard isActive else { return }
+        // Backend sent a speech update — reset the silence countdown.
+        resetSilenceTimer()
+        let newCount = newText.count   // grapheme clusters == visual cursor positions
+        sendBackspaces(insertedCount)
+        if newCount > 0 { typeString(newText) }
+        insertedCount = newCount
+    }
+
+    private func finalize(_ text: String?) {
+        cancelSilenceTimer()
+        defer { if !isActive { panel?.reattachSidecarCallbacks() } }
+        guard isActive else { return }
+        isActive = false
+        sendBackspaces(insertedCount)
+        insertedCount = 0
+        if let text, !text.isEmpty {
+            typeString(text)
+        }
+        finish()
+    }
+
+    private func finish() {
+        highlight.hide()
+        onStateChange?(false)
+        panel?.reattachSidecarCallbacks()
+    }
+
+    // MARK: - Private — CGEvent helpers
+
+    /// Send `count` Delete (⌫) key events to the frontmost app.
+    private func sendBackspaces(_ count: Int) {
+        guard count > 0 else { return }
+        let src = CGEventSource(stateID: .combinedSessionState)
+        for _ in 0..<count {
+            let dn = CGEvent(keyboardEventSource: src, virtualKey: 51, keyDown: true)
+            let up = CGEvent(keyboardEventSource: src, virtualKey: 51, keyDown: false)
+            dn?.post(tap: .cgSessionEventTap)
+            up?.post(tap: .cgSessionEventTap)
+        }
+    }
+
+    /// Type `text` at the current cursor position using a single Unicode keyboard event.
+    private func typeString(_ text: String) {
+        guard !text.isEmpty else { return }
+        let src = CGEventSource(stateID: .combinedSessionState)
+        var utf16 = Array(text.utf16)
+        let dn = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: true)
+        dn?.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: &utf16)
+        dn?.post(tap: .cgSessionEventTap)
+        let up = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: false)
+        up?.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: &utf16)
+        up?.post(tap: .cgSessionEventTap)
+    }
+}
+

--- a/Sources/Speakboard/InlineDictationController.swift
+++ b/Sources/Speakboard/InlineDictationController.swift
@@ -16,6 +16,8 @@ import AppKit
 
 final class InlineDictationController {
 
+    private let settings: SettingsStore
+
     // Injected by AppDelegate.
     weak var sidecar: SidecarManager?
     weak var panel: FloatingPanelController?
@@ -39,17 +41,25 @@ final class InlineDictationController {
 
     // MARK: - Init
 
-    init() {
+    init(settings: SettingsStore = .shared) {
+        self.settings = settings
         recorder.onChunk = { [weak self] data in
             self?.sidecar?.sendAudioChunk(data)
         }
-        // Pre-warm the audio engine so the first startRecording() is instant.
-        recorder.warmUp()
+        applySettings()
     }
 
     // MARK: - Public
 
     var isReady: Bool { sidecar?.isReady == true }
+
+    func applySettings() {
+        if settings.inlineWarmUpEnabled {
+            recorder.warmUp()
+        } else if !isActive {
+            recorder.coolDown()
+        }
+    }
 
     // MARK: Button event handlers (called by AppDelegate)
 
@@ -118,6 +128,9 @@ final class InlineDictationController {
         guard isActive else { return }
         cancelSilenceTimer()
         recorder.stopRecording()
+        if !settings.inlineWarmUpEnabled {
+            recorder.coolDown()
+        }
         sidecar?.sendStop()
         // finalize() is called asynchronously via onFinalResult.
     }
@@ -128,6 +141,9 @@ final class InlineDictationController {
         cancelSilenceTimer()
         isActive = false
         recorder.stopRecording()
+        if !settings.inlineWarmUpEnabled {
+            recorder.coolDown()
+        }
         sidecar?.cancelSession()
         if insertedCount > 0 {
             sendBackspaces(insertedCount)

--- a/Sources/Speakboard/MicButtonPanel.swift
+++ b/Sources/Speakboard/MicButtonPanel.swift
@@ -175,6 +175,7 @@ final class MicButtonPanel {
         panel.titleVisibility  = .hidden
         panel.titlebarAppearsTransparent = true
         panel.titlebarSeparatorStyle = .none
+        panel.isRestorable         = false
         panel.standardWindowButton(.closeButton)?.isHidden     = true
         panel.standardWindowButton(.miniaturizeButton)?.isHidden = true
         panel.standardWindowButton(.zoomButton)?.isHidden      = true

--- a/Sources/Speakboard/MicButtonPanel.swift
+++ b/Sources/Speakboard/MicButtonPanel.swift
@@ -5,9 +5,16 @@ import AppKit
 // The panel uses .nonactivatingPanel so clicking it NEVER steals keyboard focus
 // or application activation from the frontmost app — the cursor stays where it is.
 //
-// IMPLEMENTATION NOTE: The button is an NSButton subclass (not NSView) because
-// AppKit's event routing to NSButton inside a .nonactivatingPanel is more reliable
-// than routing to a plain NSView.
+// SPACE / MULTI-MONITOR BEHAVIOUR
+// ────────────────────────────────
+// collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary] keeps the panel
+// visible on every Mission Control Space so the user never loses access to it.
+//
+// In addition, the panel tracks its position as a *relative ratio* of the screen's
+// visible frame (saved to UserDefaults).  When the active Space changes the panel
+// repositions itself to the same proportional corner on whichever screen the cursor
+// is currently on.  This means the button always stays in "the same place" even
+// when switching between monitors with different resolutions.
 
 final class MicButtonPanel {
 
@@ -28,13 +35,123 @@ final class MicButtonPanel {
     private lazy var nsPanel: NSPanel = makePanel()
     private weak var micButton: MicHoldButton?
 
+    private var spaceObserver:  NSObjectProtocol?
+    private var screenObserver: NSObjectProtocol?
+    /// Hardware display ID of the screen the panel is currently on.
+    private var trackedDisplayID: UInt32?
+
+    // MARK: - Relative position (persisted)
+
+    private static let relXKey = "micButtonRelX"
+    private static let relYKey = "micButtonRelY"
+
+    /// Returns the saved ratio, or nil if never saved.
+    private var savedRelativePosition: NSPoint? {
+        let d = UserDefaults.standard
+        guard d.object(forKey: Self.relXKey) != nil else { return nil }
+        return NSPoint(x: d.double(forKey: Self.relXKey),
+                       y: d.double(forKey: Self.relYKey))
+    }
+
+    /// Persist the panel's current position as a ratio of its screen's visible frame,
+    /// and record the hardware display ID of that screen.
+    private func saveRelativePosition() {
+        let frame = nsPanel.frame
+        let center = NSPoint(x: frame.midX, y: frame.midY)
+        guard let screen = NSScreen.screens.first(where: { $0.frame.contains(center) })
+                ?? NSScreen.main else { return }
+        let sf = screen.visibleFrame
+        let relX = (center.x - sf.minX) / sf.width
+        let relY = (center.y - sf.minY) / sf.height
+        UserDefaults.standard.set(relX, forKey: Self.relXKey)
+        UserDefaults.standard.set(relY, forKey: Self.relYKey)
+        trackedDisplayID = screen.displayID
+    }
+
+    /// Move the panel to the saved ratio on the given screen.
+    private func restorePosition(on screen: NSScreen) {
+        let size   = nsPanel.frame.size
+        let sf     = screen.visibleFrame
+        let rel    = savedRelativePosition ?? NSPoint(x: 0.95, y: 0.05) // default: bottom-right
+        let cx     = sf.minX + rel.x * sf.width
+        let cy     = sf.minY + rel.y * sf.height
+        let origin = NSPoint(x: cx - size.width / 2, y: cy - size.height / 2)
+        nsPanel.setFrameOrigin(origin)
+    }
+
     // MARK: - Public
 
-    func show() { nsPanel.orderFrontRegardless() }
-    func hide() { nsPanel.orderOut(nil) }
+    func show() {
+        // Restore to saved position on the current screen before making visible.
+        let screen = screenAtCursor() ?? NSScreen.main
+        if let screen {
+            restorePosition(on: screen)
+            trackedDisplayID = screen.displayID
+        }
+        nsPanel.orderFrontRegardless()
+        observeSpaceChanges()
+        observeScreenChanges()
+    }
+
+    func hide() {
+        nsPanel.orderOut(nil)
+        spaceObserver  = nil
+        screenObserver = nil
+    }
 
     func setRecording(_ recording: Bool) {
         micButton?.isRecordingActive = recording
+    }
+
+    // MARK: - Space change observation
+
+    private func observeSpaceChanges() {
+        spaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.activeSpaceDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handleSpaceChange()
+        }
+    }
+
+    private func observeScreenChanges() {
+        screenObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handleScreenChange()
+        }
+    }
+
+    private func handleSpaceChange() {
+        guard let screen = screenAtCursor() ?? NSScreen.main else { return }
+        restorePosition(on: screen)
+    }
+
+    /// Called when a monitor is connected or disconnected.
+    ///
+    /// We track the *hardware display ID* of the screen the panel is on rather
+    /// than checking absolute coordinates.  When the left monitor is removed the
+    /// global coordinate system shifts, so the button's old coordinates may still
+    /// fall inside the surviving monitor's frame — but the tracked display ID is
+    /// gone, which is the reliable signal that we need to reposition.
+    private func handleScreenChange() {
+        let availableIDs = Set(NSScreen.screens.compactMap { $0.displayID })
+
+        let trackedIsGone = trackedDisplayID.map { !availableIDs.contains($0) } ?? false
+        guard trackedIsGone else { return }
+
+        let target = screenAtCursor() ?? NSScreen.main!
+        trackedDisplayID = target.displayID
+        restorePosition(on: target)
+        nsPanel.orderFrontRegardless()
+    }
+
+    private func screenAtCursor() -> NSScreen? {
+        let loc = NSEvent.mouseLocation
+        return NSScreen.screens.first { $0.frame.contains(loc) }
     }
 
     // MARK: - Panel construction
@@ -58,15 +175,18 @@ final class MicButtonPanel {
         panel.titleVisibility  = .hidden
         panel.titlebarAppearsTransparent = true
         panel.titlebarSeparatorStyle = .none
-        panel.standardWindowButton(.closeButton)?.isHidden = true
+        panel.standardWindowButton(.closeButton)?.isHidden     = true
         panel.standardWindowButton(.miniaturizeButton)?.isHidden = true
-        panel.standardWindowButton(.zoomButton)?.isHidden = true
+        panel.standardWindowButton(.zoomButton)?.isHidden      = true
 
+        // Appear on every Space and inside fullscreen apps.
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        // Initial position: default bottom-right of main screen (overridden by show()).
         if let screen = NSScreen.main {
             let sf = screen.visibleFrame
             panel.setFrameOrigin(NSPoint(x: sf.maxX - size - 24, y: sf.minY + 24))
         }
-        panel.center()
 
         let container = NSView(frame: NSRect(x: 0, y: 0, width: size, height: size))
         container.autoresizingMask = [.width, .height]
@@ -80,6 +200,7 @@ final class MicButtonPanel {
             self?.currentMode = mode
             self?.onModeChange?(mode)
         }
+        btn.onDragEnded = { [weak self] in self?.saveRelativePosition() }
         btn.autoresizingMask = [.width, .height]
         micButton = btn
 
@@ -105,6 +226,8 @@ private final class MicHoldButton: NSButton {
     /// Fired when mouse up happens without a significant drag.
     var onTap:        (() -> Void)?
     var onModeChange: ((DictationMode) -> Void)?
+    /// Fired after a drag ends so MicButtonPanel can persist the new position.
+    var onDragEnded:  (() -> Void)?
 
     var currentMode: DictationMode = .hold
 
@@ -191,7 +314,11 @@ private final class MicHoldButton: NSButton {
         dragStartWindowOrigin = nil
         hasDragged = false
 
-        if !wasDrag { onTap?() }
+        if wasDrag {
+            onDragEnded?()   // persist new relative position
+        } else {
+            onTap?()
+        }
         onRelease?()
     }
 
@@ -200,20 +327,15 @@ private final class MicHoldButton: NSButton {
     override func rightMouseDown(with event: NSEvent) {
         let menu = NSMenu(title: "")
 
-        // — Hold to Speak —
-        let holdItem = menuItem(.hold)
-        menu.addItem(holdItem)
+        menu.addItem(menuItem(.hold))
 
-        // — Click to Start (submenu) —
         let clickModes: [DictationMode] = [
             .toggle,
             .autoStop(silenceDelay: 1.0),
             .autoStop(silenceDelay: 2.0),
         ]
         let clickParent = NSMenuItem(title: "Click to Start", action: nil, keyEquivalent: "")
-        let isClickMode = clickModes.contains(currentMode)
-        if isClickMode { clickParent.state = .on }
-
+        if clickModes.contains(currentMode) { clickParent.state = .on }
         let sub = NSMenu(title: "")
         for m in clickModes { sub.addItem(menuItem(m)) }
         clickParent.submenu = sub
@@ -240,6 +362,15 @@ private final class MicHoldButton: NSButton {
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
     override var acceptsFirstResponder: Bool { false }
+}
+
+// MARK: - NSScreen display ID helper
+
+private extension NSScreen {
+    /// The CGDirectDisplayID for this screen, or nil if unavailable.
+    var displayID: UInt32? {
+        deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? UInt32
+    }
 }
 
 /// Simple wrapper so DictationMode (not an NSObject) can be stored as representedObject.

--- a/Sources/Speakboard/MicButtonPanel.swift
+++ b/Sources/Speakboard/MicButtonPanel.swift
@@ -1,0 +1,249 @@
+import AppKit
+
+// A small always-on-top floating panel containing a mic button.
+//
+// The panel uses .nonactivatingPanel so clicking it NEVER steals keyboard focus
+// or application activation from the frontmost app — the cursor stays where it is.
+//
+// IMPLEMENTATION NOTE: The button is an NSButton subclass (not NSView) because
+// AppKit's event routing to NSButton inside a .nonactivatingPanel is more reliable
+// than routing to a plain NSView.
+
+final class MicButtonPanel {
+
+    /// Fired on mouseDown (used by .hold mode).
+    var onPress:   (() -> Void)?
+    /// Fired on mouseUp (used by .hold mode).
+    var onRelease: (() -> Void)?
+    /// Fired on a tap (mouseUp with no significant drag). Used by .toggle / .autoStop modes.
+    var onTap:     (() -> Void)?
+
+    /// Current mode — used to build the right-click context menu.
+    var currentMode: DictationMode = DictationMode.load() {
+        didSet { micButton?.currentMode = currentMode }
+    }
+    /// Called when user picks a new mode from the context menu.
+    var onModeChange: ((DictationMode) -> Void)?
+
+    private lazy var nsPanel: NSPanel = makePanel()
+    private weak var micButton: MicHoldButton?
+
+    // MARK: - Public
+
+    func show() { nsPanel.orderFrontRegardless() }
+    func hide() { nsPanel.orderOut(nil) }
+
+    func setRecording(_ recording: Bool) {
+        micButton?.isRecordingActive = recording
+    }
+
+    // MARK: - Panel construction
+
+    private func makePanel() -> NSPanel {
+        let size: CGFloat = 56
+
+        let panel = MicPanel(
+            contentRect: NSRect(x: 0, y: 0, width: size, height: size),
+            styleMask: [.nonactivatingPanel, .fullSizeContentView, .titled],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level            = .floating
+        panel.isFloatingPanel  = true
+        panel.isReleasedWhenClosed = false
+        panel.hidesOnDeactivate    = false
+        panel.backgroundColor  = .clear
+        panel.isOpaque         = false
+        panel.hasShadow        = true
+        panel.titleVisibility  = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.titlebarSeparatorStyle = .none
+        panel.standardWindowButton(.closeButton)?.isHidden = true
+        panel.standardWindowButton(.miniaturizeButton)?.isHidden = true
+        panel.standardWindowButton(.zoomButton)?.isHidden = true
+
+        if let screen = NSScreen.main {
+            let sf = screen.visibleFrame
+            panel.setFrameOrigin(NSPoint(x: sf.maxX - size - 24, y: sf.minY + 24))
+        }
+        panel.center()
+
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: size, height: size))
+        container.autoresizingMask = [.width, .height]
+
+        let btn = MicHoldButton(frame: NSRect(x: 0, y: 0, width: size, height: size))
+        btn.currentMode = currentMode
+        btn.onPress   = { [weak self] in self?.onPress?() }
+        btn.onRelease = { [weak self] in self?.onRelease?() }
+        btn.onTap     = { [weak self] in self?.onTap?() }
+        btn.onModeChange = { [weak self] mode in
+            self?.currentMode = mode
+            self?.onModeChange?(mode)
+        }
+        btn.autoresizingMask = [.width, .height]
+        micButton = btn
+
+        container.addSubview(btn)
+        panel.contentView = container
+        return panel
+    }
+}
+
+// MARK: - Panel subclass
+
+private final class MicPanel: NSPanel {
+    override var canBecomeKey:  Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+
+// MARK: - Mic button (NSButton subclass)
+
+private final class MicHoldButton: NSButton {
+
+    var onPress:      (() -> Void)?
+    var onRelease:    (() -> Void)?
+    /// Fired when mouse up happens without a significant drag.
+    var onTap:        (() -> Void)?
+    var onModeChange: ((DictationMode) -> Void)?
+
+    var currentMode: DictationMode = .hold
+
+    var isRecordingActive = false {
+        didSet { needsDisplay = true }
+    }
+
+    // Drag tracking
+    private var dragStartScreenLoc: NSPoint?
+    private var dragStartWindowOrigin: NSPoint?
+    private var hasDragged = false
+    private let dragThreshold: CGFloat = 5
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        isBordered  = false
+        bezelStyle  = .rounded
+        title       = ""
+        wantsLayer  = true
+        layer?.cornerRadius = frame.width / 2
+    }
+
+    required init?(coder: NSCoder) { fatalError("not used") }
+
+    override var isFlipped: Bool { true }
+
+    // MARK: - Drawing
+
+    override func draw(_ dirtyRect: NSRect) {
+        let inset: CGFloat = 4
+        let rect = bounds.insetBy(dx: inset, dy: inset)
+
+        let circle = NSBezierPath(ovalIn: rect)
+        (isRecordingActive ? NSColor.systemRed : NSColor(white: 0.95, alpha: 0.9)).setFill()
+        circle.fill()
+
+        NSColor(white: 0, alpha: 0.10).setStroke()
+        circle.lineWidth = 0.5
+        circle.stroke()
+
+        let pointSize: CGFloat = 18
+        let cfg  = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .medium)
+        let name = isRecordingActive ? "mic.fill" : "mic"
+        if let img = NSImage(systemSymbolName: name, accessibilityDescription: nil)?
+            .withSymbolConfiguration(cfg) {
+            let tinted = img.copy() as! NSImage
+            tinted.lockFocus()
+            (isRecordingActive ? NSColor.white : NSColor.labelColor).set()
+            NSRect(origin: .zero, size: tinted.size).fill(using: .sourceAtop)
+            tinted.unlockFocus()
+            let destRect = NSRect(
+                x: (bounds.width  - tinted.size.width)  / 2,
+                y: (bounds.height - tinted.size.height) / 2,
+                width:  tinted.size.width,
+                height: tinted.size.height
+            )
+            tinted.draw(in: destRect, from: .zero, operation: .sourceOver,
+                        fraction: 1, respectFlipped: true, hints: nil)
+        }
+    }
+
+    // MARK: - Mouse tracking
+
+    override func mouseDown(with event: NSEvent) {
+        dragStartScreenLoc    = NSEvent.mouseLocation
+        dragStartWindowOrigin = window?.frame.origin
+        hasDragged = false
+        onPress?()
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let startScreen = dragStartScreenLoc,
+              let startOrigin = dragStartWindowOrigin else { return }
+        let cur = NSEvent.mouseLocation
+        let dx  = cur.x - startScreen.x
+        let dy  = cur.y - startScreen.y
+        if hypot(dx, dy) > dragThreshold { hasDragged = true }
+        window?.setFrameOrigin(NSPoint(x: startOrigin.x + dx, y: startOrigin.y + dy))
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        let wasDrag = hasDragged
+        dragStartScreenLoc    = nil
+        dragStartWindowOrigin = nil
+        hasDragged = false
+
+        if !wasDrag { onTap?() }
+        onRelease?()
+    }
+
+    // MARK: - Right-click context menu
+
+    override func rightMouseDown(with event: NSEvent) {
+        let menu = NSMenu(title: "")
+
+        // — Hold to Speak —
+        let holdItem = menuItem(.hold)
+        menu.addItem(holdItem)
+
+        // — Click to Start (submenu) —
+        let clickModes: [DictationMode] = [
+            .toggle,
+            .autoStop(silenceDelay: 1.0),
+            .autoStop(silenceDelay: 2.0),
+        ]
+        let clickParent = NSMenuItem(title: "Click to Start", action: nil, keyEquivalent: "")
+        let isClickMode = clickModes.contains(currentMode)
+        if isClickMode { clickParent.state = .on }
+
+        let sub = NSMenu(title: "")
+        for m in clickModes { sub.addItem(menuItem(m)) }
+        clickParent.submenu = sub
+        menu.addItem(clickParent)
+
+        NSMenu.popUpContextMenu(menu, with: event, for: self)
+    }
+
+    private func menuItem(_ mode: DictationMode) -> NSMenuItem {
+        let item = NSMenuItem(title: mode.menuTitle,
+                              action: #selector(modeSelected(_:)),
+                              keyEquivalent: "")
+        item.target = self
+        item.representedObject = ModeBox(mode)
+        if mode == currentMode { item.state = .on }
+        return item
+    }
+
+    @objc private func modeSelected(_ item: NSMenuItem) {
+        guard let box = item.representedObject as? ModeBox else { return }
+        currentMode = box.mode
+        onModeChange?(box.mode)
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+    override var acceptsFirstResponder: Bool { false }
+}
+
+/// Simple wrapper so DictationMode (not an NSObject) can be stored as representedObject.
+private final class ModeBox: NSObject {
+    let mode: DictationMode
+    init(_ mode: DictationMode) { self.mode = mode }
+}

--- a/Sources/Speakboard/SettingsStore.swift
+++ b/Sources/Speakboard/SettingsStore.swift
@@ -98,6 +98,7 @@ final class SettingsStore {
 
     static let defaultHotkeyKeyCode: Int = 6       // kVK_ANSI_Z
     static let defaultHotkeyModifiers: Int = 4352  // cmdKey | controlKey
+    static let defaultInlineDictationEnabled = false
     static let defaultInlineWarmUpEnabled = true
 
     var hotkeyKeyCode: Int {
@@ -107,6 +108,15 @@ final class SettingsStore {
     var hotkeyModifiers: Int {
         get { ud.object(forKey: ns + "hotkeyModifiers") as? Int ?? Self.defaultHotkeyModifiers }
         set { ud.set(newValue, forKey: ns + "hotkeyModifiers") }
+    }
+    var inlineDictationEnabled: Bool {
+        get {
+            if ud.object(forKey: ns + "inlineDictationEnabled") == nil {
+                return Self.defaultInlineDictationEnabled
+            }
+            return ud.bool(forKey: ns + "inlineDictationEnabled")
+        }
+        set { ud.set(newValue, forKey: ns + "inlineDictationEnabled") }
     }
     var inlineWarmUpEnabled: Bool {
         get {
@@ -138,6 +148,7 @@ final class SettingsStore {
          ns + "minTranscribeSecs", ns + "minSpeechSecs",
          ns + "modelPath", ns + "tokensPath",
          ns + "hotkeyKeyCode", ns + "hotkeyModifiers",
+         ns + "inlineDictationEnabled",
          ns + "inlineWarmUpEnabled"].forEach { ud.removeObject(forKey: $0) }
     }
 

--- a/Sources/Speakboard/SettingsStore.swift
+++ b/Sources/Speakboard/SettingsStore.swift
@@ -98,6 +98,7 @@ final class SettingsStore {
 
     static let defaultHotkeyKeyCode: Int = 6       // kVK_ANSI_Z
     static let defaultHotkeyModifiers: Int = 4352  // cmdKey | controlKey
+    static let defaultInlineWarmUpEnabled = true
 
     var hotkeyKeyCode: Int {
         get { ud.object(forKey: ns + "hotkeyKeyCode") as? Int ?? Self.defaultHotkeyKeyCode }
@@ -106,6 +107,15 @@ final class SettingsStore {
     var hotkeyModifiers: Int {
         get { ud.object(forKey: ns + "hotkeyModifiers") as? Int ?? Self.defaultHotkeyModifiers }
         set { ud.set(newValue, forKey: ns + "hotkeyModifiers") }
+    }
+    var inlineWarmUpEnabled: Bool {
+        get {
+            if ud.object(forKey: ns + "inlineWarmUpEnabled") == nil {
+                return Self.defaultInlineWarmUpEnabled
+            }
+            return ud.bool(forKey: ns + "inlineWarmUpEnabled")
+        }
+        set { ud.set(newValue, forKey: ns + "inlineWarmUpEnabled") }
     }
 
     var sidecarEndpoint: SidecarEndpoint {
@@ -127,7 +137,8 @@ final class SettingsStore {
          ns + "partialSilenceSecs", ns + "goldSilenceSecs", ns + "maxGoldSecs",
          ns + "minTranscribeSecs", ns + "minSpeechSecs",
          ns + "modelPath", ns + "tokensPath",
-         ns + "hotkeyKeyCode", ns + "hotkeyModifiers"].forEach { ud.removeObject(forKey: $0) }
+         ns + "hotkeyKeyCode", ns + "hotkeyModifiers",
+         ns + "inlineWarmUpEnabled"].forEach { ud.removeObject(forKey: $0) }
     }
 
     // MARK: - Config file

--- a/Sources/Speakboard/SettingsWindowController.swift
+++ b/Sources/Speakboard/SettingsWindowController.swift
@@ -28,6 +28,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private let minSpeechField     = SettingsWindowController.numberField()
     private let modelPathField     = SettingsWindowController.pathField()
     private let tokensPathField    = SettingsWindowController.pathField()
+    private let inlineWarmUpCheckbox = NSButton(checkboxWithTitle: "Keep microphone pre-warmed", target: nil, action: nil)
 
     // MARK: - Hotkey recorder state
 
@@ -143,6 +144,12 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         hotkeyLbl.alignment = .right
         grid.addRow(with: [hotkeyLbl, hotkeyStack])
 
+        header("Microphone")
+        let inlineWarmUpLabel = NSTextField(labelWithString: "Low-latency startup")
+        inlineWarmUpLabel.alignment = .right
+        inlineWarmUpCheckbox.setButtonType(.switch)
+        grid.addRow(with: [inlineWarmUpLabel, inlineWarmUpCheckbox])
+
         header("Server")
         grid.addRow(with: [
             NSTextField(labelWithString: "Transport"),
@@ -223,6 +230,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         minSpeechField.stringValue     = format(settings.minSpeechSecs)
         modelPathField.stringValue     = settings.modelPath
         tokensPathField.stringValue    = settings.tokensPath
+        inlineWarmUpCheckbox.state     = settings.inlineWarmUpEnabled ? .on : .off
     }
 
     @objc private func saveAndRestart() {
@@ -248,6 +256,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         settings.minSpeechSecs         = Double(minSpeechField.stringValue)  ?? SettingsStore.defaultMinSpeechSecs
         settings.modelPath             = modelPathField.stringValue.trimmingCharacters(in: .whitespaces)
         settings.tokensPath            = tokensPathField.stringValue.trimmingCharacters(in: .whitespaces)
+        settings.inlineWarmUpEnabled   = inlineWarmUpCheckbox.state == .on
 
         do {
             try settings.writeConfigFile()

--- a/Sources/Speakboard/SettingsWindowController.swift
+++ b/Sources/Speakboard/SettingsWindowController.swift
@@ -28,6 +28,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private let minSpeechField     = SettingsWindowController.numberField()
     private let modelPathField     = SettingsWindowController.pathField()
     private let tokensPathField    = SettingsWindowController.pathField()
+    private let inlineDictationCheckbox = NSButton(checkboxWithTitle: "Enable inline dictation (floating mic button)", target: nil, action: nil)
     private let inlineWarmUpCheckbox = NSButton(checkboxWithTitle: "Keep microphone pre-warmed", target: nil, action: nil)
 
     // MARK: - Hotkey recorder state
@@ -139,16 +140,23 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         transportPopup.target = self
         transportPopup.action = #selector(transportChanged)
 
-        header("Hotkey")
-        let hotkeyLbl = NSTextField(labelWithString: "Global shortcut")
-        hotkeyLbl.alignment = .right
-        grid.addRow(with: [hotkeyLbl, hotkeyStack])
+        header("Dictation")
+        let inlineDictationLabel = NSTextField(labelWithString: "Input mode")
+        inlineDictationLabel.alignment = .right
+        inlineDictationCheckbox.setButtonType(.switch)
+        inlineDictationCheckbox.target = self
+        inlineDictationCheckbox.action = #selector(inlineDictationToggled)
+        grid.addRow(with: [inlineDictationLabel, inlineDictationCheckbox])
 
-        header("Microphone")
         let inlineWarmUpLabel = NSTextField(labelWithString: "Low-latency startup")
         inlineWarmUpLabel.alignment = .right
         inlineWarmUpCheckbox.setButtonType(.switch)
         grid.addRow(with: [inlineWarmUpLabel, inlineWarmUpCheckbox])
+
+        header("Hotkey")
+        let hotkeyLbl = NSTextField(labelWithString: "Global shortcut")
+        hotkeyLbl.alignment = .right
+        grid.addRow(with: [hotkeyLbl, hotkeyStack])
 
         header("Server")
         grid.addRow(with: [
@@ -230,7 +238,9 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         minSpeechField.stringValue     = format(settings.minSpeechSecs)
         modelPathField.stringValue     = settings.modelPath
         tokensPathField.stringValue    = settings.tokensPath
+        inlineDictationCheckbox.state  = settings.inlineDictationEnabled ? .on : .off
         inlineWarmUpCheckbox.state     = settings.inlineWarmUpEnabled ? .on : .off
+        updateInlineRelatedControls()
     }
 
     @objc private func saveAndRestart() {
@@ -256,6 +266,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         settings.minSpeechSecs         = Double(minSpeechField.stringValue)  ?? SettingsStore.defaultMinSpeechSecs
         settings.modelPath             = modelPathField.stringValue.trimmingCharacters(in: .whitespaces)
         settings.tokensPath            = tokensPathField.stringValue.trimmingCharacters(in: .whitespaces)
+        settings.inlineDictationEnabled = inlineDictationCheckbox.state == .on
         settings.inlineWarmUpEnabled   = inlineWarmUpCheckbox.state == .on
 
         do {
@@ -275,6 +286,10 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     @objc private func resetDefaults() {
         settings.resetToDefaults()
         loadValues()
+    }
+
+    @objc private func inlineDictationToggled() {
+        updateInlineRelatedControls()
     }
 
     @objc private func transportChanged() {
@@ -410,6 +425,13 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         case .loopbackTcp:
             endpointField.placeholderString = String(SettingsStore.defaultPort)
         }
+    }
+
+    private func updateInlineRelatedControls() {
+        let inline = inlineDictationCheckbox.state == .on
+        inlineWarmUpCheckbox.isEnabled = inline
+        hotkeyDisplayField.isEnabled = !inline
+        hotkeyRecordBtn.isEnabled = !inline
     }
 
     private static func numberField() -> NSTextField {

--- a/Sources/Speakboard/SidecarManager.swift
+++ b/Sources/Speakboard/SidecarManager.swift
@@ -18,6 +18,8 @@ final class SidecarManager {
     var onPartial: ((String) -> Void)?
     /// Called whenever an accurate gold-boundary transcription arrives mid-recording (accumulated).
     var onGoldUpdate: ((String) -> Void)?
+    /// Called with append-only committed text in yolo mode.
+    var onCommit: ((String) -> Void)?
     /// Called with the final accumulated transcription after sendStop(), or nil if nothing detected.
     var onFinalResult: ((String?) -> Void)?
 
@@ -270,7 +272,14 @@ final class SidecarManager {
                 return
             }
             print("[sidecar] connected to \(transport.endpointDescription)")
-            self.sendText(#"{"type":"start"}"#)
+            let inline = self.settings.inlineDictationEnabled
+            if inline {
+                print("[sidecar] sending start with mode=yolo (inlineDictationEnabled=true)")
+                self.sendText(#"{"type":"start","mode":"yolo"}"#)
+            } else {
+                print("[sidecar] sending start without mode (inlineDictationEnabled=false)")
+                self.sendText(#"{"type":"start"}"#)
+            }
         }
         print("[sidecar] connecting to \(transport.endpointDescription)")
     }
@@ -295,6 +304,7 @@ final class SidecarManager {
             onReady?()
 
         case "partial":
+            print("[sidecar] received partial (onPartial \(onPartial == nil ? "nil" : "set"))")
             guard let t = json["text"] as? String, !t.isEmpty else { break }
             let pid = json["id"] as? String ?? "p0"
             if let idx = pendingPartials.firstIndex(where: { $0.id == pid }) {
@@ -308,6 +318,7 @@ final class SidecarManager {
             onPartial?(display)
 
         case "gold_replace":
+            print("[sidecar] received gold_replace (onGoldUpdate \(onGoldUpdate == nil ? "nil" : "set"))")
             guard let t = json["text"] as? String, !t.isEmpty else { break }
             pendingPartials = []   // gold replaces all pending partials
             sessionGoldText = sessionGoldText.isEmpty ? t : sessionGoldText + " " + t
@@ -317,6 +328,18 @@ final class SidecarManager {
                 onFinalResult?(sessionGoldText)
             } else {
                 onGoldUpdate?(sessionGoldText)
+            }
+
+        case "commit":
+            print("[sidecar] received commit (onCommit \(onCommit == nil ? "nil" : "set"))")
+            guard let t = json["text"] as? String, !t.isEmpty else { break }
+            sessionGoldText = sessionGoldText.isEmpty ? t : sessionGoldText + " " + t
+            if sessionStopped {
+                guard !finalResultDelivered else { break }
+                finalResultDelivered = true
+                onFinalResult?(sessionGoldText)
+            } else {
+                onCommit?(t)
             }
 
         default:


### PR DESCRIPTION
- MicButtonPanel: always-on-top floating mic button (NSButton in .nonactivatingPanel so it never steals focus). Supports drag to reposition and right-click context menu to switch dictation mode.

- InlineDictationController: types ASR transcription directly at the cursor position in any app via CGEvent. Handles partials (live preview with backspace correction) and final results.

- DictationMode: three trigger modes persisted to UserDefaults — • Hold to Speak (hold button, release to stop) • Click to Toggle (click once to start, again to stop) • Auto-stop Ns (click to start, stops after N seconds of silence)

- HighlightOverlay: transparent floating panel that draws a blue ring around the target window while dictation is active, using AXUIElement to locate the frontmost window frame.

- AudioRecorder: add warmUp() to pre-start AVAudioEngine so the first startRecording() opens a gate on the already-running tap instead of rebuilding the engine chain, eliminating ~200 ms startup latency.