### PR TITLE
fix: dynamic hotkey hint, untruncated section headers, endpoint tooltip

### DIFF
--- a/Sources/Speakboard/PanelContentView.swift
+++ b/Sources/Speakboard/PanelContentView.swift
@@ -75,7 +75,10 @@ final class PanelContentView: NSView {
         case .recording(.shortPress):
             hintLabel.stringValue = "↩  stop recording     Esc  cancel"
         case .recording(.longPress):
-            hintLabel.stringValue = "release ⌘⇧O  to stop     Esc  cancel"
+            let hotkey = SettingsWindowController.hotkeyDisplayString(
+                keyCode: UInt32(SettingsStore.shared.hotkeyKeyCode),
+                modifiers: UInt32(SettingsStore.shared.hotkeyModifiers))
+            hintLabel.stringValue = "release \(hotkey)  to stop     Esc  cancel"
         case .transcribing:
             hintLabel.stringValue = "Transcribing…"
         case .result:

--- a/Sources/Speakboard/SettingsWindowController.swift
+++ b/Sources/Speakboard/SettingsWindowController.swift
@@ -99,6 +99,8 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
             lbl.font = .systemFont(ofSize: 11, weight: .semibold)
             lbl.textColor = .secondaryLabelColor
             let row = grid.addRow(with: [lbl, NSGridCell.emptyContentView])
+            row.mergeCells(in: NSRange(location: 0, length: 2))
+            row.cell(at: 0).xPlacement = .leading
             row.topPadding = 12
             return row
         }
@@ -436,6 +438,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         case .loopbackTcp:
             endpointField.placeholderString = String(SettingsStore.defaultPort)
         }
+        endpointField.toolTip = endpointField.stringValue.isEmpty ? nil : endpointField.stringValue
     }
 
     private func updateInlineRelatedControls() {


### PR DESCRIPTION
## Summary

Fixes #10 — three small UI fixes in the Settings and floating panel.

## Changes

1. **Hardcoded hotkey hint**: The long-press recording hint now reads the user's configured shortcut from `SettingsStore` instead of showing a hardcoded `⌘⇧O`
2. **Truncated section headers**: Settings section header rows now merge their two grid cells with left alignment, so long titles like "Model (optional — leave blank for auto-download)" are fully readable
3. **Endpoint tooltip**: The endpoint field now shows its full value as a tooltip on hover, making long UDS socket paths readable

## Files changed

- `PanelContentView.swift` — dynamic hotkey hint generation
- `SettingsWindowController.swift` — header cell merge + endpoint tooltip

## Test plan

- [x] Verify compilation passes
- [x] Change global shortcut in Settings, long-press record, confirm the hint shows the new shortcut
- [x] Check "Model (optional — leave blank for auto-download)" header is fully visible
- [x] Hover over endpoint field with a long UDS path, confirm tooltip shows full path

🤖 Generated with [Claude Code](https://claude.com/claude-code)