### PR TITLE
fix: change default pre-warm microphone to false for consistency

### DIFF
--- a/Sources/Speakboard/SettingsStore.swift
+++ b/Sources/Speakboard/SettingsStore.swift
@@ -99,7 +99,7 @@ final class SettingsStore {
     static let defaultHotkeyKeyCode: Int = 6       // kVK_ANSI_Z
     static let defaultHotkeyModifiers: Int = 4352  // cmdKey | controlKey
     static let defaultInlineDictationEnabled = false
-    static let defaultInlineWarmUpEnabled = true
+    static let defaultInlineWarmUpEnabled = false
 
     var hotkeyKeyCode: Int {
         get { ud.object(forKey: ns + "hotkeyKeyCode") as? Int ?? Self.defaultHotkeyKeyCode }


### PR DESCRIPTION
## Summary

Fixes #19 — changes `defaultInlineWarmUpEnabled` from `true` to `false`.

## Problem

The default configuration had inline dictation disabled but pre-warm microphone enabled. Since pre-warm only has effect when inline dictation is active, this created a confusing UI state where the pre-warm checkbox appeared checked but grayed out after clicking "Reset to Defaults".

## Fix

One-line change in `SettingsStore.swift`: `defaultInlineWarmUpEnabled = true` → `false`

Now both inline dictation and pre-warm default to off, which is logically consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)